### PR TITLE
fix: suppress git errors when using outside of repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,12 @@ repos:
       - id: ruff-check
         types_or: [ python ]
         args: [ "--select", "I", "--fix" ]
-        files: ^src/matchbite/.*\.py$
       # Run the formatter.
       - id: ruff-format
         types_or: [ python ]
-        files: ^src/matchbite/.*\.py$
       - id: ruff
         name: ruff-format-imports
         args: ["check", "--select", "I", "--fix"]
-        files: ^src/matchbite/.*\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.16.0"
     hooks:

--- a/src/project_context/utils.py
+++ b/src/project_context/utils.py
@@ -2,6 +2,51 @@ import subprocess
 from pathlib import Path
 
 
+def get_root_paths(path: Path) -> tuple[Path | None, Path | None]:
+    """Returns the root path of the Git repository and the relative path from the root.
+
+    If the path is not in a Git repository, returns (None, None).
+
+    Args:
+        path: The path to check.
+
+    Returns:
+        A tuple containing the root path of the Git repository and the relative path from the root.
+        If the path is not in a Git repository, returns (None, None).
+    """
+    try:
+        if not path.exists():
+            return None, None
+
+        # Never use .git directory as cwd
+        if path.name == ".git" and path.is_dir():
+            return None, None
+
+        # Set the current working directory to the path's parent if it's a file
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=path if path.is_dir() else path.parent,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None, None
+
+        # Get the repo root relative to the path's directory
+        repo_root = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path if path.is_dir() else path.parent,
+            stderr=subprocess.DEVNULL,  # Suppress error output
+            text=True,
+        ).strip()
+        return Path(repo_root).resolve(), path.resolve().relative_to(
+            Path(repo_root).resolve()
+        )
+
+    except (subprocess.CalledProcessError, ValueError):
+        return None, None
+
+
 def is_file_tracked(path: str | Path) -> bool:
     """Checks if a file is tracked by Git.
 
@@ -12,45 +57,17 @@ def is_file_tracked(path: str | Path) -> bool:
         True if the file is tracked, False otherwise.
     """
     try:
-        path_obj = Path(path)
-        # Determine working directory more safely
-        if path_obj.is_file():
-            work_dir = path_obj.parent
-        elif path_obj.is_dir():
-            work_dir = path_obj
-        else:
-            # Path doesn't exist, try parent directory
-            work_dir = path_obj.parent
-
-        # Check if working directory exists
-        if not work_dir.exists():
+        path = Path(path)
+        # First check whether we're in a git repository
+        repo_root, relative_path = get_root_paths(path)
+        if not repo_root:
             return False
-
-        # Check if we're in a git repository first
-        result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            cwd=work_dir,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            return False
-
-        # Get the repo root relative to the path's directory
-        repo_root = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=work_dir,
-            text=True,
-        ).strip()
-
-        # Make path relative to its git repo root
-        relative_path = Path(path).resolve().relative_to(Path(repo_root).resolve())
 
         # Run git ls-files to check if the file is tracked
         subprocess.check_output(
             ["git", "ls-files", "--error-unmatch", str(relative_path)],
             cwd=repo_root,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.DEVNULL,  # Suppress error output
             text=True,
         )
         return True
@@ -68,29 +85,17 @@ def is_path_gitignored(path: str | Path) -> bool:
         True if the path is ignored, False otherwise.
     """
     try:
-        # Check if we're in a git repository first
-        result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            cwd=Path(path).parent if Path(path).is_file() else path,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
+        path = Path(path)
+        # First check whether we're in a git repository
+        repo_root, relative_path = get_root_paths(path)
+        if not repo_root:
             return False
 
-        # Get repo root relative to the path's directory
-        repo_root = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=Path(path).parent if Path(path).is_file() else path,
-            text=True,
-        ).strip()
-
-        relative_path = Path(path).resolve().relative_to(Path(repo_root).resolve())
-        result_bytes = subprocess.run(
+        result = subprocess.run(
             ["git", "check-ignore", "--quiet", str(relative_path)],
             cwd=repo_root,
             capture_output=True,
         )
-        return result_bytes.returncode == 0
+        return result.returncode == 0
     except (subprocess.CalledProcessError, ValueError):
         return False

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,9 @@
-import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
+
 from project_context.main import main
 
 

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,12 +1,14 @@
-import pytest
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from project_context.main import main
 from project_context.tree import (
     ProjectPath,
     ProjectTree,
 )
-from project_context.main import main
 
 
 class TestProjectPath:


### PR DESCRIPTION
* suppresses error message `fatal: This operation must be run in a work tree` when calling utility functions outside of git repo
* adds check that .git directory is not used as CWD when calling utility functions